### PR TITLE
give access to input devices to the input group

### DIFF
--- a/mdev.conf
+++ b/mdev.conf
@@ -87,7 +87,7 @@ psaux       root:root 660 >misc/
 rtc         root:root 664 >misc/
 
 # input stuff
-#SUBSYSTEM=input;.* root:root 600
+#SUBSYSTEM=input;.* root:input 660
 
 # v4l stuff
 vbi[0-9]    root:video 660 >v4l/


### PR DESCRIPTION
Needed for running pygame apps as unprivileged user, for example.